### PR TITLE
ci: use PR-based version bump to respect branch protection

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   bump:
@@ -45,10 +46,11 @@ jobs:
           sed -i "s/versionCode\s*=\s*[0-9]\+/versionCode = $((CODE+1))/" "$FILE"
           echo "versionCode: $CODE -> $((CODE+1))"
 
-      - name: Commit and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add VERSION android/app/build.gradle.kts
-          git commit -m "chore: bump version to ${{ steps.next.outputs.version }}"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: bump version to ${{ steps.next.outputs.version }}"
+          title: "chore: bump version to ${{ steps.next.outputs.version }}"
+          body: "Automated version bump: `${{ steps.current.outputs.version }}` → `${{ steps.next.outputs.version }}`"
+          branch: chore/bump-${{ steps.next.outputs.version }}
+          delete-branch: true


### PR DESCRIPTION
## 📝 Description
Version Bump ワークフローが main ブランチの保護ルール（署名必須・PR必須・CIチェック必須）で `git push` に失敗していた問題を修正。直接 push を `peter-evans/create-pull-request@v7` に置き換え、PR 経由でバージョンバンプが行われるようにした。

## 🗣️ Type of Change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

## 🔗 Linked Issue
Version Bump workflow run [#22544886515](https://github.com/KarakuriAgent/clawdroid/actions/runs/22544886515) failed with `protected branch hook declined`

## 📚 Technical Context (Skip for Docs)
* **Reference:** https://github.com/peter-evans/create-pull-request
* **Reasoning:** `GITHUB_TOKEN` による直接 push は branch protection の署名検証・PRルール・ステータスチェックを通過できない。PR ベースに変更することで既存の保護ルールを維持しつつ自動化を実現する。

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.