### PR TITLE
fix: fix fdroiddata build template

### DIFF
--- a/fdroid/metadata/io.clawdroid.yml
+++ b/fdroid/metadata/io.clawdroid.yml
@@ -30,7 +30,6 @@ Builds:
     commit: '0.4.0'
     timeout: 20000
     subdir: android/app
-    submodules: true
 
     sudo:
       - apt-get update
@@ -56,10 +55,6 @@ Builds:
       - embedded
 
     ndk: r27c
-
-    antifeatures:
-      NonFreeNet:
-        en-US: Requires a third-party LLM API to function.
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags


### PR DESCRIPTION
## Summary
- Remove `submodules: true` — repo has no submodules, causing `NoSubmodulesException` on F-Droid build server
- Remove duplicate per-build `antifeatures` block — already defined globally with both en-US and ja translations

## Context
F-Droid CI pipeline failed: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/34144

🤖 Generated with [Claude Code](https://claude.com/claude-code)