### PR TITLE
fix: fix fdroiddata build and update check

### DIFF
--- a/fdroid/metadata/io.clawdroid.yml
+++ b/fdroid/metadata/io.clawdroid.yml
@@ -30,11 +30,9 @@ Builds:
     commit: '0.4.0'
     timeout: 20000
     subdir: android/app
-
     sudo:
       - apt-get update
-      - apt-get install -y make
-
+      - apt-get install -y make wget
     init: |-
       cd ../..
       # Extract Go version from go.mod
@@ -43,20 +41,18 @@ Builds:
       wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
       tar -C $HOME -xzf go${GO_VERSION}.linux-amd64.tar.gz
       rm go${GO_VERSION}.linux-amd64.tar.gz
-
+    gradle:
+      - embedded
     prebuild: |-
       cd ../..
       export PATH=$HOME/go/bin:$PATH
       export GOPATH=$HOME/gopath
       # Build Go backend for all Android architectures
       make build-android
-
-    gradle:
-      - embedded
-
     ndk: r27c
 
 AutoUpdateMode: Version
-UpdateCheckMode: Tags
+UpdateCheckMode: HTTP
+UpdateCheckData: https://raw.githubusercontent.com/KarakuriAgent/clawdroid/main/android/app/build.gradle.kts|versionCode\s*=\s*(\d+)|https://raw.githubusercontent.com/KarakuriAgent/clawdroid/main/VERSION|(.+)
 CurrentVersion: 0.4.0
 CurrentVersionCode: 4


### PR DESCRIPTION
## Summary
- Add `wget` to sudo packages — `wget: command not found` in init step
- Switch `UpdateCheckMode` to `HTTP` with `UpdateCheckData` — `versionName` is dynamic (read from `VERSION` file), so tag-based parsing fails
- Reorder build fields to match `fdroid rewritemeta` canonical order
- Remove empty lines between build fields to pass `fdroid rewritemeta` diff check

## Context
F-Droid CI pipeline failures: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/34144

🤖 Generated with [Claude Code](https://claude.com/claude-code)