### PR TITLE
fix: address fdroiddata reviewer feedback

### DIFF
--- a/fdroid/metadata/io.clawdroid.yml
+++ b/fdroid/metadata/io.clawdroid.yml
@@ -30,6 +30,7 @@ Builds:
       - embedded
     build:
       - cd ../..
+      - export GOTOOLCHAIN=auto
       - export GOPATH=$HOME/gopath
       - make build-android
     ndk: r27c


### PR DESCRIPTION
## Summary
- `scanignore` を削除: Goビルドを `prebuild` → `build` に移動しスキャナー後に.so生成
- GoをDebianパッケージからインストール、`GOTOOLCHAIN=auto` で自動バージョンアップグレード
- `init` ブロック削除、`build` をリスト形式に
- `UpdateCheckMode` を `Tags` に変更（リポジトリ内相対パス指定）

## Test plan
- [x] fdroiddata MR #34144 のCI全パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)