### PR TITLE
feat: add listening pause/resume toggle to AssistantPillBar

### DIFF
--- a/android/app/src/main/java/io/clawdroid/assistant/AssistantService.kt
+++ b/android/app/src/main/java/io/clawdroid/assistant/AssistantService.kt
@@ -308,6 +308,7 @@ class AssistantService : LifecycleService(), SavedStateRegistryOwner {
                             isAtTop = overlayAtTop,
                             onClose = { shutdown() },
                             onInterrupt = { assistantManager.interrupt() },
+                            onListeningPauseToggle = { assistantManager.toggleListeningPause() },
                             onPositionChange = { top -> moveOverlayTo(top) },
                             onCameraToggle = { handleCameraToggle() },
                             onScreenCaptureToggle = { handleScreenCaptureToggle() },

--- a/android/core/domain/src/main/java/io/clawdroid/core/domain/model/VoicePhase.kt
+++ b/android/core/domain/src/main/java/io/clawdroid/core/domain/model/VoicePhase.kt
@@ -1,5 +1,5 @@
 package io.clawdroid.core.domain.model
 
 enum class VoicePhase {
-    IDLE, LISTENING, SENDING, THINKING, SPEAKING, ERROR
+    IDLE, LISTENING, PAUSED, SENDING, THINKING, SPEAKING, ERROR
 }

--- a/android/feature/chat/src/main/java/io/clawdroid/feature/chat/assistant/AssistantManager.kt
+++ b/android/feature/chat/src/main/java/io/clawdroid/feature/chat/assistant/AssistantManager.kt
@@ -3,8 +3,8 @@ package io.clawdroid.feature.chat.assistant
 import android.content.ContentResolver
 import android.speech.SpeechRecognizer
 import android.util.Base64
-import androidx.core.net.toUri
 import android.util.Log
+import androidx.core.net.toUri
 import io.clawdroid.core.domain.model.AssistantMessage
 import io.clawdroid.core.domain.model.VoicePhase
 import io.clawdroid.core.domain.repository.AssistantConnection
@@ -24,6 +24,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -42,6 +43,8 @@ class AssistantManager(
 
     private val _state = MutableStateFlow(VoiceModeState())
     val state: StateFlow<VoiceModeState> = _state.asStateFlow()
+
+    private val _isPaused = MutableStateFlow(false)
 
     private var loopJob: Job? = null
     private var parentScope: CoroutineScope? = null
@@ -69,6 +72,19 @@ class AssistantManager(
         }
     }
 
+    fun toggleListeningPause() {
+        when (_state.value.phase) {
+            VoicePhase.LISTENING -> {
+                _isPaused.value = true
+                _state.update { it.copy(phase = VoicePhase.PAUSED) }
+            }
+            VoicePhase.PAUSED -> {
+                _isPaused.value = false
+            }
+            else -> Unit
+        }
+    }
+
     fun start(scope: CoroutineScope) {
         if (loopJob?.isActive == true) return
         parentScope = scope
@@ -84,6 +100,7 @@ class AssistantManager(
         loopJob?.cancel()
         loopJob = null
         parentScope = null
+        _isPaused.value = false
         ttsWrapper.stop()
         cameraCaptureManager.unbind()
         _state.value = VoiceModeState()
@@ -96,6 +113,7 @@ class AssistantManager(
         ttsWrapper.stop()
         loopJob?.cancel()
         loopJob = null
+        _isPaused.value = false
 
         _state.update {
             VoiceModeState(isActive = true, phase = VoicePhase.LISTENING, isCameraActive = it.isCameraActive, isScreenCaptureActive = it.isScreenCaptureActive, chatHistory = it.chatHistory)
@@ -128,6 +146,7 @@ class AssistantManager(
 
         try {
             while (isActive) {
+                _isPaused.value = false
                 _state.update {
                     it.copy(
                         phase = VoicePhase.LISTENING,
@@ -138,13 +157,26 @@ class AssistantManager(
                 }
 
                 val userTextChannel = Channel<String?>(1)
+                var pausedDuringListen = false
                 val listenJob = launch {
                     val text = listen()
                     userTextChannel.send(text)
                 }
 
+                val pauseWatcher = launch {
+                    _isPaused.first { it }
+                    pausedDuringListen = true
+                    listenJob.cancel()
+                    _isPaused.first { !it }
+                    _state.update {
+                        it.copy(phase = VoicePhase.LISTENING, amplitudeNormalized = 0f)
+                    }
+                    userTextChannel.send(null)
+                }
+
                 select<Unit> {
                     userTextChannel.onReceive { text ->
+                        pauseWatcher.cancel()
                         if (!text.isNullOrBlank()) {
                             _state.update { it.copy(phase = VoicePhase.SENDING, recognizedText = text, chatHistory = it.chatHistory + ChatTurn("user", text)) }
                             try {
@@ -161,11 +193,14 @@ class AssistantManager(
                                 return@onReceive
                             }
                             awaitAndSpeakResponse(speechQueue)
+                        } else if (pausedDuringListen) {
+                            // Pause caused the null — resume listening from the top
                         } else {
                             drainSpeechQueue(speechQueue)
                         }
                     }
                     speechQueue.onReceive { content ->
+                        pauseWatcher.cancel()
                         listenJob.cancel()
                         speakAndDrain(content, speechQueue)
                     }

--- a/android/feature/chat/src/main/java/io/clawdroid/feature/chat/assistant/AssistantPillBar.kt
+++ b/android/feature/chat/src/main/java/io/clawdroid/feature/chat/assistant/AssistantPillBar.kt
@@ -60,14 +60,13 @@ import io.clawdroid.core.ui.theme.TextSecondary
 import io.clawdroid.feature.chat.voice.CameraCaptureManager
 import io.clawdroid.feature.chat.voice.ChatTurn
 import io.clawdroid.feature.chat.voice.VoiceModeState
+import io.clawdroid.feature.chat.voice.isInterruptable
+import io.clawdroid.feature.chat.voice.phaseColor
 import com.composables.icons.lucide.R as LucideR
 import kotlin.math.PI
 import kotlin.math.sin
 
 private val PillBackground = Color(0xE6141428)
-private val ListeningColor = Color(0xFF00D4FF)
-private val ThinkingColor = Color(0xFFA855F7)
-private val SpeakingColor = Color(0xFF22C55E)
 private val ErrorColor = Color(0xFFEF4444)
 
 @Composable
@@ -76,6 +75,7 @@ fun AssistantPillBar(
     isAtTop: Boolean,
     onClose: () -> Unit,
     onInterrupt: () -> Unit,
+    onListeningPauseToggle: () -> Unit,
     onPositionChange: (Boolean) -> Unit,
     onCameraToggle: () -> Unit,
     onScreenCaptureToggle: () -> Unit,
@@ -85,9 +85,6 @@ fun AssistantPillBar(
     val isExpanded = state.phase == VoicePhase.THINKING ||
         state.phase == VoicePhase.SPEAKING ||
         state.phase == VoicePhase.ERROR
-
-    val interruptable = state.phase != VoicePhase.LISTENING &&
-        state.phase != VoicePhase.IDLE
 
     var historyExpanded by remember { mutableStateOf(false) }
 
@@ -226,7 +223,7 @@ fun AssistantPillBar(
                     modifier = Modifier
                         .fillMaxWidth()
                         .then(
-                            if (interruptable) {
+                            if (state.phase.isInterruptable) {
                                 Modifier.clickable(
                                     indication = null,
                                     interactionSource = remember { MutableInteractionSource() }
@@ -235,15 +232,24 @@ fun AssistantPillBar(
                         ),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // Mic icon
-                    Icon(
-                        painter = painterResource(LucideR.drawable.lucide_ic_mic),
-                        contentDescription = "Microphone",
-                        modifier = Modifier.size(20.dp),
-                        tint = phaseColor(state.phase)
-                    )
-
-                    Spacer(modifier = Modifier.width(8.dp))
+                    // Mic icon — tap to pause/resume listening
+                    val micEnabled = state.phase == VoicePhase.LISTENING ||
+                        state.phase == VoicePhase.PAUSED
+                    IconButton(
+                        onClick = onListeningPauseToggle,
+                        enabled = micEnabled,
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(
+                                if (state.phase == VoicePhase.PAUSED) LucideR.drawable.lucide_ic_mic_off
+                                else LucideR.drawable.lucide_ic_mic
+                            ),
+                            contentDescription = if (state.phase == VoicePhase.PAUSED) "Resume listening" else "Pause listening",
+                            modifier = Modifier.size(20.dp),
+                            tint = phaseColor(state.phase)
+                        )
+                    }
 
                     // Waveform
                     WaveformBar(
@@ -382,6 +388,7 @@ private fun WaveformBar(
                     val dynamic = amplitude * 0.85f * ((wave + 1f) / 2f)
                     (base + dynamic) * size.height
                 }
+                VoicePhase.PAUSED -> 0.12f * size.height
                 VoicePhase.THINKING -> {
                     val wave = sin(normalizedX * 3f * PI.toFloat() + animPhase * 2f)
                     (0.2f + 0.15f * ((wave + 1f) / 2f)) * size.height
@@ -403,11 +410,3 @@ private fun WaveformBar(
     }
 }
 
-private fun phaseColor(phase: VoicePhase): Color = when (phase) {
-    VoicePhase.LISTENING -> ListeningColor
-    VoicePhase.SENDING -> Color(0xFFFF8C42)
-    VoicePhase.THINKING -> ThinkingColor
-    VoicePhase.SPEAKING -> SpeakingColor
-    VoicePhase.ERROR -> ErrorColor
-    VoicePhase.IDLE -> Color(0xFF4A5568)
-}

--- a/android/feature/chat/src/main/java/io/clawdroid/feature/chat/voice/VoiceModeOverlay.kt
+++ b/android/feature/chat/src/main/java/io/clawdroid/feature/chat/voice/VoiceModeOverlay.kt
@@ -109,13 +109,10 @@ fun VoiceModeOverlay(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                val interruptable = state.phase != VoicePhase.LISTENING &&
-                    state.phase != VoicePhase.IDLE
-
                 VoiceOrb(
                     phase = state.phase,
                     amplitudeNormalized = state.amplitudeNormalized,
-                    modifier = if (interruptable) {
+                    modifier = if (state.phase.isInterruptable) {
                         Modifier.clickable(
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() }
@@ -215,6 +212,7 @@ fun VoiceModeOverlay(
 private fun phaseLabel(phase: VoicePhase): String = when (phase) {
     VoicePhase.IDLE -> ""
     VoicePhase.LISTENING -> "Listening..."
+    VoicePhase.PAUSED -> "Paused"
     VoicePhase.SENDING -> "Sending..."
     VoicePhase.THINKING -> "Thinking..."
     VoicePhase.SPEAKING -> "Speaking..."

--- a/android/feature/chat/src/main/java/io/clawdroid/feature/chat/voice/VoiceOrb.kt
+++ b/android/feature/chat/src/main/java/io/clawdroid/feature/chat/voice/VoiceOrb.kt
@@ -22,13 +22,6 @@ import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 
-private val ListeningColor = Color(0xFF00D4FF)
-private val SendingColor = Color(0xFFFF8C42)
-private val ThinkingColor = Color(0xFFA855F7)
-private val SpeakingColor = Color(0xFF22C55E)
-private val ErrorColor = Color(0xFFEF4444)
-private val IdleColor = Color(0xFF4A5568)
-
 @Composable
 fun VoiceOrb(
     phase: VoicePhase,
@@ -74,14 +67,7 @@ fun VoiceOrb(
         label = "glow"
     )
 
-    val primaryColor = when (phase) {
-        VoicePhase.LISTENING -> ListeningColor
-        VoicePhase.SENDING -> SendingColor
-        VoicePhase.THINKING -> ThinkingColor
-        VoicePhase.SPEAKING -> SpeakingColor
-        VoicePhase.ERROR -> ErrorColor
-        VoicePhase.IDLE -> IdleColor
-    }
+    val primaryColor = phaseColor(phase)
 
     Canvas(modifier = modifier.size(200.dp)) {
         val center = Offset(size.width / 2f, size.height / 2f)

--- a/android/feature/chat/src/main/java/io/clawdroid/feature/chat/voice/VoicePhaseUi.kt
+++ b/android/feature/chat/src/main/java/io/clawdroid/feature/chat/voice/VoicePhaseUi.kt
@@ -1,0 +1,27 @@
+package io.clawdroid.feature.chat.voice
+
+import androidx.compose.ui.graphics.Color
+import io.clawdroid.core.domain.model.VoicePhase
+
+val VoicePhase.isInterruptable: Boolean
+    get() = this == VoicePhase.SENDING ||
+        this == VoicePhase.THINKING ||
+        this == VoicePhase.SPEAKING
+
+private val ListeningColor = Color(0xFF00D4FF)
+private val SendingColor = Color(0xFFFF8C42)
+private val ThinkingColor = Color(0xFFA855F7)
+private val SpeakingColor = Color(0xFF22C55E)
+private val ErrorColor = Color(0xFFEF4444)
+private val PausedColor = Color(0xFFFBBF24)
+private val IdleColor = Color(0xFF4A5568)
+
+fun phaseColor(phase: VoicePhase): Color = when (phase) {
+    VoicePhase.LISTENING -> ListeningColor
+    VoicePhase.PAUSED -> PausedColor
+    VoicePhase.SENDING -> SendingColor
+    VoicePhase.THINKING -> ThinkingColor
+    VoicePhase.SPEAKING -> SpeakingColor
+    VoicePhase.ERROR -> ErrorColor
+    VoicePhase.IDLE -> IdleColor
+}


### PR DESCRIPTION
## 📝 Description
AssistantPillBar のマイクアイコンをタップして、LISTENING 中の音声認識（STT）を一時停止/再開できるようにした。

- `VoicePhase.PAUSED` enum を追加し、pause 中は amber カラーと `mic_off` アイコンで視覚的にフィードバック
- `AssistantManager` に `_isPaused` StateFlow と `pauseWatcher` コルーチンで pause/resume サイクルを管理
- 共有ユーティリティ `VoicePhaseUi.kt` に `phaseColor()` と `isInterruptable` を抽出し、重複コードを削減

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)


## 🔗 Linked Issue
Closes #29

## 📚 Technical Context (Skip for Docs)
* **Reference:** N/A
* **Reasoning:** AssistantPillBar の静的マイクアイコンを `IconButton` に変更し、`AssistantManager.voiceLoop()` 内に `pauseWatcher` コルーチンを追加。pause 中は `listenJob` をキャンセルしつつ `speechQueue` と `collectorJob` は維持し、エージェントメッセージを失わない設計。


## 🧪 Test Environment & Hardware
- **Hardware:** PC
- **OS:** Linux
- **Model/Provider:** N/A (ビルド・Lint・ユニットテストのみ)
- **Channels:** N/A


## 📸 Proof of Work (Optional for Docs)
<details>
<summary>Click to view Logs/Screenshots</summary>

- `./gradlew test` — ユニットテスト通過
- `./gradlew lint` — Lint チェック通過
- `./gradlew assembleTermuxRelease` — ビルド成功

### 手動テスト項目
- [ ] LISTENING 中にマイクアイコンをタップ → PAUSED（amber、mic_off）に遷移
- [ ] PAUSED 中にマイクアイコンをタップ → LISTENING に復帰し STT 再開
- [ ] PAUSED 中にバックエンドからメッセージ受信 → 正常に speech 再生
- [ ] SENDING/THINKING/SPEAKING 中はマイクボタンが非活性
</details>


## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [ ] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)