### PR TITLE
fix: remove [silent] from session history to prevent LLM leakage

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -687,7 +687,6 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (str
 
 	// Handle NO_REPLY token — suppress sending to user
 	if strings.TrimSpace(finalContent) == SilentReplyToken {
-		al.sessions.AddMessage(opts.SessionKey, "assistant", "[silent]")
 		_ = al.sessions.Save(opts.SessionKey)
 		if opts.EnableSummary {
 			al.maybeSummarize(opts.SessionKey, opts.Channel, opts.ChatID)


### PR DESCRIPTION
## 問題

Issue #43: `NO_REPLY` トークン処理時にセッション履歴へ `[silent]` を assistant メッセージとして保存していた。`GetHistory()` はフィルタなしで全メッセージを返すため、`[silent]` が LLM コンテキストに混入し、LLM がそのまま出力してしまう。

## 原因箇所

`pkg/agent/loop.go:690`:
```go
// Before (問題のコード)
if strings.TrimSpace(finalContent) == SilentReplyToken {
    al.sessions.AddMessage(opts.SessionKey, "assistant", "[silent]")  // ← これが原因
    _ = al.sessions.Save(opts.SessionKey)
    ...
}
```

## 修正内容

`AddMessage` の呼び出しを削除。セッションの保存（`Save`）は引き続き行うが、`[silent]` マーカーを履歴に書き込まない。

```go
// After (修正後)
if strings.TrimSpace(finalContent) == SilentReplyToken {
    _ = al.sessions.Save(opts.SessionKey)
    ...
}
```

## 変更ファイル

- `pkg/agent/loop.go`: `AddMessage` 呼び出し1行を削除（-1行）

## テスト確認

- `go build ./pkg/agent/...` 成功
- `NO_REPLY` トークン受信後のセッション履歴に `[silent]` が残らないことを確認

Closes #43