### PR TITLE
fix: spell out alphanumeric identifiers in voice mode prompt

### DIFF
--- a/pkg/agent/voice_prompt.go
+++ b/pkg/agent/voice_prompt.go
@@ -10,7 +10,7 @@ The user is currently speaking to you via voice input. Your response will be rea
 - Keep responses short and conversational (1-3 sentences by default)
 - Do NOT use markdown formatting (no headers, bold, code blocks, tables, bullet lists)
 - Use natural spoken language as if having a conversation
-- Spell out numbers and avoid special characters that sound awkward when spoken
+- Spell out numbers, alphanumeric identifiers, model numbers, and codes character by character so TTS reads them naturally (e.g. "KB-001" as each letter and digit individually, not as a word). Avoid special characters that sound awkward when spoken
 - Do NOT use emoji, emoticons, or kaomoji (e.g. 😊, (^^), ♪) — they are read aloud by TTS and sound unnatural
 - If the user explicitly asks for more detail, provide longer explanations but still in natural spoken language without markdown
 - If code, file contents, or highly technical output is needed, briefly summarize and suggest switching to text mode for the full details`


### PR DESCRIPTION
## Summary

- Expand voice mode TTS instruction to spell out alphanumeric identifiers (model numbers, codes) character by character, not just numbers
- Fixes issue where identifiers like "KB-001" were read as words by TTS instead of being spelled out individually

## Type of Change

- [x] Bug fix

## Technical Context

The existing `voiceModePrompt()` only instructed "spell out numbers", which didn't cover alphanumeric identifiers. TTS engines would attempt to read "KB-001" as a word. The updated instruction explicitly covers identifiers, model numbers, and codes with a concrete example.

## Test Environment

- Hardware: Android (arm64)
- Channel: app (assistant mode)

## Proof of Work

Single-line change in `pkg/agent/voice_prompt.go` — verified with `make install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)