### PR TITLE
feat: add descriptive text to setup wizard steps

### DIFF
--- a/android/app/src/main/java/io/clawdroid/setup/SetupCompleteScreen.kt
+++ b/android/app/src/main/java/io/clawdroid/setup/SetupCompleteScreen.kt
@@ -50,7 +50,8 @@ fun SetupCompleteScreen(
         Spacer(Modifier.height(12.dp))
 
         Text(
-            "You can change these settings later from the Settings screen.",
+            "You can change these settings anytime from the Settings screen, " +
+                "where you'll also find additional options such as channel configuration and tool management.",
             style = MaterialTheme.typography.bodyMedium,
             color = TextSecondary,
         )

--- a/android/app/src/main/java/io/clawdroid/setup/SetupStep1GatewayScreen.kt
+++ b/android/app/src/main/java/io/clawdroid/setup/SetupStep1GatewayScreen.kt
@@ -59,7 +59,8 @@ fun SetupStep1GatewayScreen(viewModel: SetupViewModel) {
             color = TextPrimary,
         )
         Text(
-            "Configure the HTTP gateway that connects this app to the backend.",
+            "The gateway handles communication between this app and the Go backend running locally. " +
+                "An API key is required to authenticate requests between them.",
             style = MaterialTheme.typography.bodyMedium,
             color = TextSecondary,
         )
@@ -73,7 +74,12 @@ fun SetupStep1GatewayScreen(viewModel: SetupViewModel) {
             placeholder = { Text("18790", color = TextSecondary.copy(alpha = 0.5f)) },
             singleLine = true,
             isError = uiState.gatewayPortError != null,
-            supportingText = uiState.gatewayPortError?.let { err -> { Text(err) } },
+            supportingText = {
+                Text(
+                    uiState.gatewayPortError
+                        ?: "Local port for backend communication (default: 18790)",
+                )
+            },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             colors = setupFieldColors(),
             modifier = Modifier.fillMaxWidth(),
@@ -84,6 +90,9 @@ fun SetupStep1GatewayScreen(viewModel: SetupViewModel) {
             onValueChange = viewModel::onGatewayApiKeyChange,
             label = { Text("API Key", color = TextSecondary) },
             singleLine = true,
+            supportingText = {
+                Text("Secures communication between this app and the backend. Use 'Generate' to create one automatically.")
+            },
             visualTransformation = if (apiKeyHidden) PasswordVisualTransformation() else VisualTransformation.None,
             trailingIcon = {
                 TextButton(onClick = { apiKeyHidden = !apiKeyHidden }) {

--- a/android/app/src/main/java/io/clawdroid/setup/SetupStep2LlmScreen.kt
+++ b/android/app/src/main/java/io/clawdroid/setup/SetupStep2LlmScreen.kt
@@ -48,7 +48,9 @@ fun SetupStep2LlmScreen(viewModel: SetupViewModel) {
         Text("Step 2 of 4", style = MaterialTheme.typography.labelMedium, color = TextSecondary)
         Text("LLM Settings", style = MaterialTheme.typography.headlineMedium, color = TextPrimary)
         Text(
-            "Configure the language model used by the agent.",
+            "Choose which AI model powers the agent. " +
+                "Supported providers are OpenAI, Anthropic, and Gemini. " +
+                "Enter the model name in provider/model format.",
             style = MaterialTheme.typography.bodyMedium,
             color = TextSecondary,
         )
@@ -59,7 +61,10 @@ fun SetupStep2LlmScreen(viewModel: SetupViewModel) {
             value = uiState.llmModel,
             onValueChange = viewModel::onLlmModelChange,
             label = { Text("Model", color = TextSecondary) },
-            placeholder = { Text("e.g. openai/gpt-4o", color = TextSecondary.copy(alpha = 0.5f)) },
+            placeholder = { Text("provider/model", color = TextSecondary.copy(alpha = 0.5f)) },
+            supportingText = {
+                Text("Format: provider/model (e.g. openai/gpt-5, anthropic/claude-sonnet-4-6, gemini/gemini-3.1-flash)")
+            },
             singleLine = true,
             colors = setupFieldColors(),
             modifier = Modifier.fillMaxWidth(),
@@ -69,6 +74,9 @@ fun SetupStep2LlmScreen(viewModel: SetupViewModel) {
             value = uiState.llmApiKey,
             onValueChange = viewModel::onLlmApiKeyChange,
             label = { Text("API Key", color = TextSecondary) },
+            supportingText = {
+                Text("API key from your LLM provider (OpenAI, Anthropic, or Gemini)")
+            },
             singleLine = true,
             visualTransformation = if (apiKeyHidden) PasswordVisualTransformation() else VisualTransformation.None,
             trailingIcon = {
@@ -88,7 +96,9 @@ fun SetupStep2LlmScreen(viewModel: SetupViewModel) {
             value = uiState.llmBaseUrl,
             onValueChange = viewModel::onLlmBaseUrlChange,
             label = { Text("Base URL", color = TextSecondary) },
-            placeholder = { Text("https://openrouter.ai/api/v1", color = TextSecondary.copy(alpha = 0.5f)) },
+            supportingText = {
+                Text("Custom API endpoint. Leave empty to use the provider's default.")
+            },
             singleLine = true,
             colors = setupFieldColors(),
             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/java/io/clawdroid/setup/SetupStep3WorkspaceScreen.kt
+++ b/android/app/src/main/java/io/clawdroid/setup/SetupStep3WorkspaceScreen.kt
@@ -62,7 +62,8 @@ fun SetupStep3WorkspaceScreen(viewModel: SetupViewModel) {
         Text("Step 3 of 4", style = MaterialTheme.typography.labelMedium, color = TextSecondary)
         Text("Workspace & Data", style = MaterialTheme.typography.headlineMedium, color = TextPrimary)
         Text(
-            "Set the workspace and data directories used by the agent.",
+            "The workspace is where the agent reads and writes your files. " +
+                "The data directory stores internal data such as memory and logs.",
             style = MaterialTheme.typography.bodyMedium,
             color = TextSecondary,
         )
@@ -74,6 +75,7 @@ fun SetupStep3WorkspaceScreen(viewModel: SetupViewModel) {
             onValueChange = viewModel::onWorkspaceChange,
             label = "Workspace",
             placeholder = "~/.clawdroid/workspace",
+            supportingText = "Directory where the agent reads and writes files",
             onBrowse = { workspacePicker.launch(null) },
         )
 
@@ -82,6 +84,7 @@ fun SetupStep3WorkspaceScreen(viewModel: SetupViewModel) {
             onValueChange = viewModel::onDataDirChange,
             label = "Data Directory",
             placeholder = "~/.clawdroid/data",
+            supportingText = "Directory for internal data such as memory and logs",
             onBrowse = { dataDirPicker.launch(null) },
         )
 
@@ -113,6 +116,7 @@ private fun DirectoryField(
     onValueChange: (String) -> Unit,
     label: String,
     placeholder: String,
+    supportingText: String = "",
     onBrowse: () -> Unit,
 ) {
     OutlinedTextField(
@@ -120,6 +124,11 @@ private fun DirectoryField(
         onValueChange = onValueChange,
         label = { Text(label, color = TextSecondary) },
         placeholder = { Text(placeholder, color = TextSecondary.copy(alpha = 0.5f)) },
+        supportingText = if (supportingText.isNotEmpty()) {
+            { Text(supportingText) }
+        } else {
+            null
+        },
         singleLine = true,
         trailingIcon = {
             IconButton(


### PR DESCRIPTION
## 📝 Description
セットアップウィザードの各ステップにおいて、ステップ説明文の充実と各入力フィールドへの `supportingText` 追加を行い、初回ユーザーが各設定の意味を理解しやすくした。

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🔗 Linked Issue
Closes #39

## 📚 Technical Context (Skip for Docs)
* **Reference:** N/A
* **Reasoning:** 各 `OutlinedTextField` の `supportingText` パラメータを使用して説明文を常時表示。Step 3 の `DirectoryField` composable には `supportingText: String` パラメータを新規追加。Step 1 の Port フィールドではエラー時にエラーメッセージを優先表示するロジックを維持。

## 🧪 Test Environment & Hardware
- **Hardware:** N/A (UI text changes only)
- **OS:** N/A
- **Model/Provider:** N/A
- **Channels:** N/A

## 📸 Proof of Work (Optional for Docs)
<details>
<summary>Click to view Logs/Screenshots</summary>
UI テキスト変更のみ。手動での画面確認を推奨。
</details>

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)