### PR TITLE
feat: add AAB output for Google Play release

### DIFF
--- a/.github/workflows/android-aab.yml
+++ b/.github/workflows/android-aab.yml
@@ -1,0 +1,55 @@
+name: Android AAB
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-aab:
+    name: Build Embedded AAB
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build Go binaries for Android
+        run: make build-android
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        working-directory: android
+        run: echo "$KEYSTORE_BASE64" | base64 -d > release.keystore
+
+      - name: Create keystore.properties
+        env:
+          STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        working-directory: android
+        run: |
+          printf 'storeFile=release.keystore\nstorePassword=%s\nkeyAlias=%s\nkeyPassword=%s\n' \
+            "$STORE_PASSWORD" "$KEY_ALIAS" "$KEY_PASSWORD" > keystore.properties
+
+      - name: Build release AAB
+        working-directory: android
+        run: ./gradlew bundleEmbeddedRelease
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clawdroid-embedded-release.aab
+          path: android/app/build/outputs/bundle/embeddedRelease/app-embedded-release.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,10 @@ jobs:
         working-directory: android
         run: ./gradlew assembleEmbeddedRelease -PenableAbiSplit
 
+      - name: Build release AAB
+        working-directory: android
+        run: ./gradlew bundleEmbeddedRelease
+
       - name: Upload APKs to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,3 +152,12 @@ jobs:
             clawdroid-"$RELEASE_TAG"-armeabi-v7a.apk \
             clawdroid-"$RELEASE_TAG"-x86_64.apk \
             clawdroid-"$RELEASE_TAG"-universal.apk
+
+      - name: Upload AAB to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        working-directory: android/app/build/outputs/bundle/embeddedRelease
+        run: |
+          mv app-embedded-release.aab clawdroid-"$RELEASE_TAG".aab
+          gh release upload "$RELEASE_TAG" clawdroid-"$RELEASE_TAG".aab


### PR DESCRIPTION
## 📝 Description
リリース時に Google Play アップロード用の AAB (Android App Bundle) を出力するようにする。

- `release.yml` の Embedded ジョブに `bundleEmbeddedRelease` ステップを追加し、AAB をリリースアセットにアップロード
- 手動実行用の単独ワークフロー `android-aab.yml` を新規作成（`workflow_dispatch`）

## 🗣️ Type of Change
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 📖 Documentation update
- [ ] ⚡ Code refactoring (no functional changes, no api changes)

## 🔗 Linked Issue

## 📚 Technical Context (Skip for Docs)
* **Reasoning:** Google Play では APK ではなく AAB でのアップロードが推奨/必須。AAB は全 ABI を含み、Google Play 側で端末に合った APK を自動生成・配信する。

## ☑️ Checklist
- [x] My code/docs follow the style of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)